### PR TITLE
Fix to prevent getParameterMetaData being called for each param

### DIFF
--- a/src/main/java/org/j8ql/DB.java
+++ b/src/main/java/org/j8ql/DB.java
@@ -307,6 +307,10 @@ public class DB {
 			if (vals == null) {
 				return pStmt;
 			}
+
+			// Grab metadata here outside of the vals loop to prevent major performance issues
+			ParameterMetaData pmd = pStmt.getParameterMetaData();
+
 			for (int i = 0; i < vals.length; i++) {
 				int cidx = i + 1;
 				Object val = vals[i];
@@ -315,7 +319,6 @@ public class DB {
 				if (val == null) {
 					pStmt.setObject(cidx, null);
 				} else {
-					ParameterMetaData pmd = pStmt.getParameterMetaData();
 					ConvertContext ctx = new ConvertContext(pmd, i + 1);
 
 					val = getDbVal(val, ctx);


### PR DESCRIPTION
This issue causes a significant slow down when there are more than a few parameters being used in a given prepared statement.  Fix reduces number of getParameterMetaData calls to once per query execution instead of scaling up with number of parameters.