### PR TITLE
Make UUID object allowed for use with j8ql

### DIFF
--- a/src/main/java/org/j8ql/DB.java
+++ b/src/main/java/org/j8ql/DB.java
@@ -369,7 +369,7 @@ public class DB {
 
 	// Broad assumptions
 	static private final Set<String> dbCompatiblePackages = Maps.setOf("java.lang", "java.sql", "java.math");
-	static private final Set<Class> dbCompatibleClasses = Maps.setOf(ZonedDateTime.class);
+	static private final Set<Class> dbCompatibleClasses = Maps.setOf(ZonedDateTime.class, UUID.class);
 
 	private boolean isStandardDbCompatibleType(Class cls) {
 		return (cls.isPrimitive() || Map.class.isAssignableFrom(cls)


### PR DESCRIPTION
For our use case we need to be able to use UUID's as a database column type.  From testing the existing handling in j8ql for built in postgres types seems to allow UUID columns to get mapped to UUID typed member variables just fine, if UUID.class is just added to the hard coded dbCompatibleClasses Set.