### PR TITLE
Add onConflictDoNothing flag to InsertQueries

### DIFF
--- a/src/main/java/org/j8ql/RunnerImpl.java
+++ b/src/main/java/org/j8ql/RunnerImpl.java
@@ -174,7 +174,7 @@ public class RunnerImpl implements Runner {
 				Integer num = query.executeUpdate(values);
 				return (T) num;
 			}else {
-				Record rec = query.executeWithSingleReturn(values).get();
+				Record rec = query.executeWithSingleReturn(values).orElse(null);
 
 				if (rec != null){
 					if (Primitives.isWrapperType(asClass)){

--- a/src/main/java/org/j8ql/generator/PGInsertGenerator.java
+++ b/src/main/java/org/j8ql/generator/PGInsertGenerator.java
@@ -51,6 +51,10 @@ public class PGInsertGenerator extends PGGenerator {
 		sbValues.append(")");
 		sql.append(' ').append(sbNames).append(" VALUES ").append(sbValues);
 
+		if(insertBuilder.isOnConflictDoNothing()){
+			sql.append(" ON CONFLICT DO NOTHING ");
+		}
+
 		// RETURNING
 		processReturningSql(insertBuilder, tableDef, sql);
 

--- a/src/main/java/org/j8ql/query/InsertQuery.java
+++ b/src/main/java/org/j8ql/query/InsertQuery.java
@@ -11,6 +11,7 @@ import java.util.List;
  * <p></p>
  */
 public class InsertQuery<T> extends IUQuery<T> implements Columns<InsertQuery<T>>      {
+	private boolean onConflictDoNothing = false;
 
 	// ---------Base Constructors --------- //
 	private InsertQuery(Class<T> asClass){
@@ -25,6 +26,7 @@ public class InsertQuery<T> extends IUQuery<T> implements Columns<InsertQuery<T>
 
 	private InsertQuery(InsertQuery insertBuilder, Class<T> asClass) {
 		super(insertBuilder, asClass);
+		this.onConflictDoNothing = insertBuilder.onConflictDoNothing;
 	}
 	// --------- /Clone Constructors --------- //
 
@@ -88,4 +90,13 @@ public class InsertQuery<T> extends IUQuery<T> implements Columns<InsertQuery<T>
 		return returning(new InsertQuery<A>(this, returningAs), returningAs, returningColumns);
 	}
 	// --------- /Returning --------- //
+
+	public InsertQuery<T> onConflictDoNothing(){
+		this.onConflictDoNothing = true;
+		return new InsertQuery<T>(this);
+	}
+
+	public boolean isOnConflictDoNothing(){
+		return onConflictDoNothing;
+	}
 }


### PR DESCRIPTION
Another piece of postgres functionality we need to be able to use: the `ON CONFLICT DO NOTHING` feature for inserts.  This implementation is more narrowly scoped than it could be, but I don't really have much intimate knowledge of the internals of j8ql to be comfortable adding this across the whole architecture.  Eg: It might be preferable to add the new flag to the parent IUQuery class that InsertQuery extends as inserts and updates could make use of the feature as well.  Additionally, is there a clean j8ql way to allow configuring this option in more than just on/off state so that you can specify `ON CONFLICT DO <something>`?